### PR TITLE
Add support to special characters

### DIFF
--- a/test.py
+++ b/test.py
@@ -34,3 +34,11 @@ class TestMatrixCreation(unittest.TestCase):
 
             # The two rows from the two libraries should be identical
             self.assertEqual(len(micro_row), len(macro_row))
+
+class TestWifiCreation(unittest.TestCase):
+    def test_render_matrix(self):
+        micro_qr = MicroQRCode()
+        ssid, password = 'test', 'test'
+        micro_qr.add_data('WIFI:S:{};T:WPA;P:{};H:false;;'.format(ssid, password))
+        matrix = micro_qr.render_matrix()
+        self.assertGreater(len(matrix), 0)

--- a/uQR.py
+++ b/uQR.py
@@ -388,7 +388,7 @@ MODE_SIZE_LARGE = {
     MODE_KANJI: 12,
 }
 
-ALPHA_NUM = b'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:'
+ALPHA_NUM = b'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:;#&{}[](),=\'"\\'
 
 RE_ALPHA_NUM = re.compile(b'^[' + ALPHA_NUM + b']*')
 # The number of bits for numeric delimited data lengths.


### PR DESCRIPTION
As a developer I'd like to generate QR codes for making mobile devices connect to the specified network. Right now the library  doesn't support the required alphanumeric character `;`  so I'm creating this PR for making it work and also adding some other characters.

The current behavior of the application is raising an exception:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "uQR.py", line 1276, in get_matrix
  File "uQR.py", line 1043, in make
  File "uQR.py", line 1109, in best_fit
  File "uQR.py", line 810, in write
TypeError: can't convert 'int' object to str implicitly
```